### PR TITLE
Pass props as context to `lazy` function

### DIFF
--- a/src/forms/FieldLoader.jsx
+++ b/src/forms/FieldLoader.jsx
@@ -86,7 +86,7 @@ class FieldLoader extends React.Component {
         }
 
         // Extend the descriptor asynchronously
-        const descPromise = Promise.resolve(this.props.desc.lazy())
+        const descPromise = Promise.resolve(this.props.desc.lazy.apply(this.props))
         descPromise.then(asyncDesc => this.setState(asyncDesc))
 
         watch('reload', (props) => {


### PR DESCRIPTION
This will allow lazy to setup dynamic options based on the props it has.
Use case: Hide a field based on the data it will receive (we could use `crudl.context`), but it wont work for TabViews.