### PR TITLE
[Hotfix] Fix typo `Promise.methode` -> `Promise.method`

### DIFF
--- a/src/forms/FieldSet.jsx
+++ b/src/forms/FieldSet.jsx
@@ -51,7 +51,7 @@ class FieldSet extends React.Component {
         const fields = asArray(onChange.in).map(name => props.fields[name])
 
         // Set the props
-        Promise.methode(asFunc(onChange.setProps))(...fields)
+        Promise.method(asFunc(onChange.setProps))(...fields)
         .then((newProps) => {
             this.setState(newProps)
         })


### PR DESCRIPTION
Type: Hotfix
From: 881a34598c7a7863c3f58c761bcd6d632a2a98a7