### PR TITLE
Expose fields

### DIFF
--- a/src/Crudl.jsx
+++ b/src/Crudl.jsx
@@ -50,6 +50,7 @@ import wrapComponent from './utils/wrapComponent'
 import validateAdmin from './utils/validateAdmin'
 import Request from './Request'
 import baseField from './fields/base/baseField'
+import fields from './fields'
 import simpleViewSchema from './admin-schema/simpleView'
 
 import DevTools from './containers/DevTools'
@@ -76,7 +77,7 @@ export const context = createContext(contextData)
 export const path = {}
 
 
-export { baseField }
+export { baseField, fields }
 
 export function setStore(newStore) {
     store = newStore


### PR DESCRIPTION
This allows the developers to place conditional field rendering.
Current lazy function does not fit that purpose entirely.

Example:

```
        {
          id: 'redacted',
          name: 'redacted',
          label: 'redacted',
          field: (props) => (! props.input.value ? crudl.fields.Select(props) : crudl.fields.hidden(props)),
          require: true,
          lazy: function (props) {
            // if ( props.fields.redacted && props.fields.redacted.value ) {
            //  return { hidden: true }
            //}

            return redacted.read(crudl.req().filter('redacted', crudl.context('_id')))
          }
        },
```