### PR TITLE
Fix TypeError in setTimeNow() method & ensure InlinesView.handleAdd calls denormalize properly

### DIFF
--- a/src/containers/InlinesView.jsx
+++ b/src/containers/InlinesView.jsx
@@ -105,7 +105,7 @@ class InlinesView extends React.Component {
     handleAdd(index, data) {
         const { desc, dispatch, intl } = this.props
         if (hasPermission(desc.id, 'add')) {
-            return handleErrors(desc.actions.add(req(normalize(desc, data))))
+            return handleErrors(desc.actions.add(req(denormalize(desc, data))))
             .then((res) => {
                 const items = this.state.items.slice()
                 items[index].new = false

--- a/src/fields/TimeField.jsx
+++ b/src/fields/TimeField.jsx
@@ -17,7 +17,7 @@ class TimeField extends React.Component {
     };
 
     setTimeNow() {
-        this.props.input.autofill(this.props.formatTime(new Date()))
+        this.props.input.onChange(this.props.formatTime(new Date()))
     }
 
     render() {


### PR DESCRIPTION
Corrects the following issues:
------------------------------
Change `setTimeNow()` method to use `input.onChange` inline with
`DateTimeField.jsx`. The current `input.autofill` call is throwing a
`TypeError` exception when used:

`Uncaught TypeError: this.props.input.autofill is not a function`

------------------------------
Fix `InlineViews.handleAdd` to ensure it calls `denormalize` rather than `normalize` before it sends to the `add` action.

This was causing the implementation `normalize` handler to be called when sending data to the backend rather than the opposite.